### PR TITLE
Disable some SQL check rules for columns and tables

### DIFF
--- a/sql-review-override.yml
+++ b/sql-review-override.yml
@@ -24,6 +24,8 @@ ruleList:
     payload:
       format: ^([A-Z][a-z]*)+$
       maxLength: 63
+  - type: naming.identifier.no-keyword
+    level: DISABLED
   - type: column.maximum-character-length
     level: WARNING
     payload:

--- a/sql-review-override.yml
+++ b/sql-review-override.yml
@@ -3,6 +3,8 @@ template: bb.sql-review.prod
 ruleList:
   - type: table.require-pk
     level: ERROR
+  - type: table.no-foreign-key
+    level: DISABLED
   - type: statement.select.no-select-all
     level: ERROR
   - type: statement.where.require
@@ -31,3 +33,7 @@ ruleList:
   - type: column.maximum-varchar-length
     payload:
       number: 255
+  - type: column.required
+    level: DISABLED
+  - type: column.require-default
+    level: DISABLED


### PR DESCRIPTION
## Description

Disable some SQL check rules for columns and tables:

- table.no-foreign-key -> To allow foreign keys creation
- column.required -> To avoid check about a default required colums ("created_ts", "creator_id" ...).
- column.require-default -> To avoid check about a default required default values for each column
- naming.identifier.no-keyword -> To avoid check about keyboards as table names

